### PR TITLE
Fix file type detection error.

### DIFF
--- a/knowsmore/cmd/bloodhound.py
+++ b/knowsmore/cmd/bloodhound.py
@@ -95,7 +95,7 @@ class Bloodhound(CmdBase):
                 # Obtain meta tag
                 js.seek(-0x100, os.SEEK_END)
                 lastbytes = str(js.read(0x100), 'utf-8').strip()
-                metatagstr = re.search(r'"meta"\s*:\s*{(?:.|\n)*?}', lastbytes, re.MULTILINE | re.IGNORECASE).group(0)
+                metatagstr = re.search(r'"meta":\s*{(?:.|\n)*?}', lastbytes, re.MULTILINE | re.IGNORECASE).group(0)
                 metatag = json.loads('{' + metatagstr + '}')
                 return metatag.get('meta', {})
 

--- a/knowsmore/cmd/bloodhound.py
+++ b/knowsmore/cmd/bloodhound.py
@@ -94,8 +94,8 @@ class Bloodhound(CmdBase):
             with open(self.file_name, 'rb') as js:
                 # Obtain meta tag
                 js.seek(-0x100, os.SEEK_END)
-                lastbytes = str(js.read(0x100))
-                metatagstr = re.search('("meta":(\s+)?{.*})}', lastbytes, re.MULTILINE | re.IGNORECASE).group(1)
+                lastbytes = str(js.read(0x100), 'utf-8').strip()
+                metatagstr = re.search(r'"meta"\s*:\s*{(?:.|\n)*?}', lastbytes, re.MULTILINE | re.IGNORECASE).group(0)
                 metatag = json.loads('{' + metatagstr + '}')
                 return metatag.get('meta', {})
 


### PR DESCRIPTION
There was a detection error when the bloodhound generated file contains new line chars inside the `meta` property.

This error was happening because the  while reading the last `0x100` bytes of the file, the `get_meta` function was not sanitizing those bytes properly to avoid special chars being escaped. So, the regex search was not able to match the file type properly. 

EX: 
If a json file's last `0x100` bytes ended-up like this: 
```json
 "meta": {
  "type": "domains",
  "count": 1,
  "version": 5
 }
```
After being converted to string in this line:
```python
lastbytes = str(js.read(0x100))
```
I would ended up like this: 
```json
"meta": {\n  "type": "domains",\n  "count": 1,\n  "version": 5\n }
```
Causing the regex to fails its validation. 

Now, my implementation casts and parses the files last `0x100` bytes properly and also the regex was updated to detect files containing new line chars or not. 
This line of code makes sure it will strip any chars properly, avoiding special chars to be escaped. 
```python
lastbytes = str(js.read(0x100), 'utf-8').strip()
```
And the regex (`r'"meta"\s*:\s*{(?:.|\n)*?}'`) will detect files like this: 
```json
"meta":{"methods":0,"type":"computers","count":40000, "version":5}
```
or like this 
```json
 "meta": {
  "type": "domains",
  "count": 1,
  "version": 5
 }
```