### PR TITLE
Update wordlist.py

### DIFF
--- a/knowsmore/cmd/wordlist.py
+++ b/knowsmore/cmd/wordlist.py
@@ -141,6 +141,8 @@ class WordList(CmdBase):
         else:
             self.char_space = LEETS1
 
+        self.char_space['.'] = '.'
+
         self.unique_chars = set([v for l1 in [list(value) for value in self.char_space.values()] for v in l1])
         self.unique_ch_b = int(np.sum([len(v.encode("UTF-8")) for v in self.unique_chars]))
 


### PR DESCRIPTION
Added the code snippet: **"self.char_space['.'] = '.'"**, to fix the issue of generating wordlists in words _(--names)_ that contain _"."_ (dot), e.g., user.sec4us.

Before the addition of the code snippet **"self.char_space['.'] = '.'"**.
![2](https://github.com/helviojunior/knowsmore/assets/96009982/1239c356-6216-46ef-90ff-6b29239cb2ce)

After adding the code snippet **"self.char_space['.'] = '.'"**.
![1](https://github.com/helviojunior/knowsmore/assets/96009982/40d67ea8-2872-4fe6-96f6-facf6f4a6213)



